### PR TITLE
Support for polar coordinates in `Vector2`

### DIFF
--- a/tests/test_vector2.py
+++ b/tests/test_vector2.py
@@ -378,6 +378,7 @@ class TestVMathVector2(unittest.TestCase):
             angleResult = v1.angle(Vector2(0, 0))
 
     def test_polar(self):
+        # polar <-> cartesian conversions
         cases = [
             # ((rho, theta), (x, y))
             ((1, 0), (1, 0)),
@@ -395,6 +396,24 @@ class TestVMathVector2(unittest.TestCase):
             v = Vector2(x, y)
             self.assertAlmostEqual(v.rho, rho)
             self.assertAlmostEqual(v.theta, theta)
+
+        # degrees -> radians
+        cases = [
+            # (degrees, radians)
+            (0, 0),
+            (90, np.pi/2),
+            (-90, -np.pi/2),
+            (45, np.pi/4),
+            (180, np.pi),
+        ]
+        for deg, rad in cases:
+            v = Vector2(1, deg, polar=True, unit='deg')
+            self.assertAlmostEqual(v.theta, rad)
+            self.assertAlmostEqual(v.theta_deg, deg)
+
+        # faulty input
+        with self.assertRaises(ValueError):
+            Vector2(1, np.pi, polar=True, unit='invalid_unit')
 
 
 if __name__ == '__main__':

--- a/tests/test_vector2.py
+++ b/tests/test_vector2.py
@@ -414,6 +414,26 @@ class TestVMathVector2(unittest.TestCase):
         # faulty input
         with self.assertRaises(ValueError):
             Vector2(1, np.pi, polar=True, unit='invalid_unit')
+        with self.assertRaises(ValueError):
+            v = Vector2(1, np.pi, polar=True)
+            # copying doesn't support polar=True
+            Vector2(v, polar=True)
+
+    def test_spherical(self):
+        # cartesian -> sperical conversions
+        cases = [
+            # ((x, y, z), (rho, theta, phi))
+            ((1, 0, 0), (1, 0, np.pi/2)),
+            ((1, 0, 1), (np.sqrt(2), 0, np.pi/4)),
+            ((1, 0, -1), (np.sqrt(2), 0, np.pi/4*3)),
+        ]
+        for cartesian, sperical in cases:
+            rho, theta, phi = sperical
+            x, y, z = cartesian
+            v = Vector3(x, y, z)
+            self.assertAlmostEqual(v.rho, rho)
+            self.assertAlmostEqual(v.theta, theta)
+            self.assertAlmostEqual(v.phi, phi)
 
 
 if __name__ == '__main__':

--- a/tests/test_vector2.py
+++ b/tests/test_vector2.py
@@ -377,6 +377,25 @@ class TestVMathVector2(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError):
             angleResult = v1.angle(Vector2(0, 0))
 
+    def test_polar(self):
+        cases = [
+            # ((rho, theta), (x, y))
+            ((1, 0), (1, 0)),
+            ((1, np.pi), (-1, 0)),
+            ((2, -np.pi / 2), (0, -2)),
+            ((1, np.pi * 3 / 4), (-1 / np.sqrt(2), 1 / np.sqrt(2))),
+            ((3, np.pi / 4), (3 / np.sqrt(2), 3 / np.sqrt(2))),
+        ]
+        for polar, cartesian in cases:
+            rho, theta = polar
+            x, y = cartesian
+            v = Vector2(rho, theta, polar=True)
+            self.assertAlmostEqual(v.x, x)
+            self.assertAlmostEqual(v.y, y)
+            v = Vector2(x, y)
+            self.assertAlmostEqual(v.rho, rho)
+            self.assertAlmostEqual(v.theta, theta)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/vectormath/vector.py
+++ b/vectormath/vector.py
@@ -202,6 +202,8 @@ class Vector2(BaseVector):
                 return cls(0, 0, polar, unit)
             if np.isscalar(X) and np.isscalar(Y):
                 if polar:
+                    if unit not in ['deg', 'rad']:
+                        raise ValueError('Only units of rad or deg are supported')
                     if unit == 'deg':
                         Y = Y / 180 * np.pi
                     X, Y = X * np.cos(Y), X * np.sin(Y)
@@ -233,12 +235,14 @@ class Vector2(BaseVector):
         return self.length
 
     @property
-    def theta(self, unit='rad'):
-        """Angular coordinate of this vector in polar coordinates"""
-        theta = float(np.arctan2(self.y, self.x))
-        if unit == 'deg':
-            theta = theta * 180 / np.pi
-        return theta
+    def theta(self):
+        """Angular coordinate (in radians) of this vector in polar coordinates"""
+        return float(np.arctan2(self.y, self.x))
+
+    @property
+    def theta_deg(self):
+        """Angular coordinate (in degrees) of this vector in polar coordinates"""
+        return float(np.arctan2(self.y, self.x)) * 180 / np.pi
 
     def cross(self, vec):
         """Cross product with another vector"""

--- a/vectormath/vector.py
+++ b/vectormath/vector.py
@@ -50,6 +50,38 @@ class BaseVector(np.ndarray):
             raise ZeroDivisionError('Cannot resize vector of length 0 to '
                                     'nonzero length')
 
+    @property
+    def rho(self):
+        """Radial coordinate of this vector (equal to the length of the vector)"""
+        return self.length
+
+    @rho.setter
+    def rho(self, value):
+        self.length = value
+
+    @property
+    def theta(self):
+        """
+        Angular coordinate / azimuthal angle (in radians) of this vector
+        in polar coordinates (or sperical coordinates for `Vector3`)
+        i.e. the angle between this vector and the positive x-axis (-pi <= theta <= pi)
+        """
+        return float(np.arctan2(self.y, self.x))
+
+    # TODO: Add `theta` and `theta_deg` setters
+    # @theta.setter
+    # def theta(self, value):
+    #     ...
+
+    @property
+    def theta_deg(self):
+        """
+        Angular coordinate / azimuthal angle (in degrees) of this vector
+        in polar coordinates (or sperical coordinates for `Vector3`)
+        i.e. the angle between this vector and the positive x-axis (-180 <= theta_deg <= 180)
+        """
+        return self.theta * 180 / np.pi
+
     def as_length(self, value):
         """Return a new vector scaled to given length"""
         new_vec = self.copy()
@@ -120,6 +152,7 @@ class Vector3(BaseVector):
         - no input (returns [0., 0., 0.])
     """
 
+    # TODO: add support for instantiating Vector3 with `polar`=True
     def __new__(cls, x=None, y=None, z=None):                                  #pylint: disable=arguments-differ
 
         def read_array(X, Y, Z):
@@ -178,6 +211,27 @@ class Vector3(BaseVector):
     def z(self, value):
         self[2] = value
 
+    @property
+    def phi(self):
+        """
+        Polar angle / inclination (in radians) of this vector in sperical coordinates
+        i.e. the angle between this vector and the positive z-azis (0 <= phi <= pi)
+        """
+        return np.arctan2(np.sqrt(self.x**2 + self.y**2), self.z)
+
+    # TODO: Add `phi` and `phi_deg` setters
+    # @phi.setter
+    # def phi(self, value):
+    #     ...
+
+    @property
+    def phi_deg(self):
+        """
+        Polar angle / inclination (in degrees) of this vector in sperical coordinates
+        i.e. the angle between this vector and the positive z-axis (0 <= phi_deg <= 180)
+        """
+        return self.phi * 180 / np.pi
+
 
 class Vector2(BaseVector):
     """Primitive 2D vector defined from the origin
@@ -186,6 +240,7 @@ class Vector2(BaseVector):
         - another Vector2
         - length-2 array
         - x and y values
+        - rho and theta, if polar=True; specify unit as 'rad' (default) or 'deg'
         - no input (returns [0., 0.])
     """
 
@@ -194,7 +249,9 @@ class Vector2(BaseVector):
         def read_array(X, Y):
             """Build Vector2 from another Vector2, [x, y], or x/y"""
             if isinstance(X, cls) and Y is None:
-                return cls(X.x, X.y, polar, unit)
+                if polar:
+                    raise ValueError('When copying a Vector2, polar=True is not supported')
+                return cls(X.x, X.y)
             if (isinstance(X, (list, tuple, np.ndarray)) and len(X) == 2 and
                     Y is None):
                 return cls(X[0], X[1], polar, unit)
@@ -228,21 +285,6 @@ class Vector2(BaseVector):
             raise ValueError(
                 'Invalid array to view as Vector2 - must be length-2 array.'
             )
-
-    @property
-    def rho(self):
-        """Radial coordinate of this vector in polar coordinates"""
-        return self.length
-
-    @property
-    def theta(self):
-        """Angular coordinate (in radians) of this vector in polar coordinates"""
-        return float(np.arctan2(self.y, self.x))
-
-    @property
-    def theta_deg(self):
-        """Angular coordinate (in degrees) of this vector in polar coordinates"""
-        return float(np.arctan2(self.y, self.x)) * 180 / np.pi
 
     def cross(self, vec):
         """Cross product with another vector"""

--- a/vectormath/vector.py
+++ b/vectormath/vector.py
@@ -189,18 +189,22 @@ class Vector2(BaseVector):
         - no input (returns [0., 0.])
     """
 
-    def __new__(cls, x=None, y=None):                                          #pylint: disable=arguments-differ
+    def __new__(cls, x=None, y=None, polar=False, unit='rad'):                 #pylint: disable=arguments-differ
 
         def read_array(X, Y):
             """Build Vector2 from another Vector2, [x, y], or x/y"""
             if isinstance(X, cls) and Y is None:
-                return cls(X.x, X.y)
+                return cls(X.x, X.y, polar, unit)
             if (isinstance(X, (list, tuple, np.ndarray)) and len(X) == 2 and
                     Y is None):
-                return cls(X[0], X[1])
+                return cls(X[0], X[1], polar, unit)
             if X is None and Y is None:
-                return cls(0, 0)
+                return cls(0, 0, polar, unit)
             if np.isscalar(X) and np.isscalar(Y):
+                if polar:
+                    if unit == 'deg':
+                        Y = Y / 180 * np.pi
+                    X, Y = X * np.cos(Y), X * np.sin(Y)
                 xyz = np.r_[X, Y]
                 xyz = xyz.astype(float)
                 return xyz.view(cls)
@@ -222,6 +226,19 @@ class Vector2(BaseVector):
             raise ValueError(
                 'Invalid array to view as Vector2 - must be length-2 array.'
             )
+
+    @property
+    def rho(self):
+        """Radial coordinate of this vector in polar coordinates"""
+        return self.length
+
+    @property
+    def theta(self, unit='rad'):
+        """Angular coordinate of this vector in polar coordinates"""
+        theta = float(np.arctan2(self.y, self.x))
+        if unit == 'deg':
+            theta = theta * 180 / np.pi
+        return theta
 
     def cross(self, vec):
         """Cross product with another vector"""

--- a/vectormath/vector.py
+++ b/vectormath/vector.py
@@ -68,6 +68,7 @@ class BaseVector(np.ndarray):
         """
         return float(np.arctan2(self.y, self.x))
 
+    # pylint: disable=fixme
     # TODO: Add `theta` and `theta_deg` setters
     # @theta.setter
     # def theta(self, value):
@@ -152,7 +153,9 @@ class Vector3(BaseVector):
         - no input (returns [0., 0., 0.])
     """
 
+    # pylint: disable=fixme
     # TODO: add support for instantiating Vector3 with `polar`=True
+
     def __new__(cls, x=None, y=None, z=None):                                  #pylint: disable=arguments-differ
 
         def read_array(X, Y, Z):
@@ -219,6 +222,7 @@ class Vector3(BaseVector):
         """
         return np.arctan2(np.sqrt(self.x**2 + self.y**2), self.z)
 
+    # pylint: disable=fixme
     # TODO: Add `phi` and `phi_deg` setters
     # @phi.setter
     # def phi(self, value):

--- a/vectormath/vector.py
+++ b/vectormath/vector.py
@@ -62,9 +62,11 @@ class BaseVector(np.ndarray):
     @property
     def theta(self):
         """
-        Angular coordinate / azimuthal angle (in radians) of this vector
-        in polar coordinates (or sperical coordinates for `Vector3`)
-        i.e. the angle between this vector and the positive x-axis (-pi <= theta <= pi)
+        Angular coordinate / azimuthal angle of this vector in radians
+
+        Based on polar coordinate space (or sperical coordinate space for `Vector3`)
+        returns angle between this vector and the positive x-axis
+        range: (-pi <= theta <= pi)
         """
         return float(np.arctan2(self.y, self.x))
 
@@ -77,9 +79,11 @@ class BaseVector(np.ndarray):
     @property
     def theta_deg(self):
         """
-        Angular coordinate / azimuthal angle (in degrees) of this vector
-        in polar coordinates (or sperical coordinates for `Vector3`)
-        i.e. the angle between this vector and the positive x-axis (-180 <= theta_deg <= 180)
+        Angular coordinate / azimuthal angle of this vector in degrees
+
+        Based on polar coordinate space (or sperical coordinate space for `Vector3`)
+        returns angle between this vector and the positive x-axis
+        range: (-180 <= theta_deg <= 180)
         """
         return self.theta * 180 / np.pi
 
@@ -217,8 +221,11 @@ class Vector3(BaseVector):
     @property
     def phi(self):
         """
-        Polar angle / inclination (in radians) of this vector in sperical coordinates
-        i.e. the angle between this vector and the positive z-azis (0 <= phi <= pi)
+        Polar angle / inclination of this vector in radians
+
+        Based on sperical coordinate space
+        returns angle between this vector and the positive z-azis
+        range: (0 <= phi <= pi)
         """
         return np.arctan2(np.sqrt(self.x**2 + self.y**2), self.z)
 
@@ -231,8 +238,11 @@ class Vector3(BaseVector):
     @property
     def phi_deg(self):
         """
-        Polar angle / inclination (in degrees) of this vector in sperical coordinates
-        i.e. the angle between this vector and the positive z-axis (0 <= phi_deg <= 180)
+        Polar angle / inclination of this vector in degrees
+
+        Based on sperical coordinate space
+        returns angle between this vector and the positive z-azis
+        range: (0 <= phi <= pi)
         """
         return self.phi * 180 / np.pi
 


### PR DESCRIPTION
 - Constructor accepts polar coordinates (with the optional `polar` keyword argument)
 - `Vector2` instances have `rho` and `theta` as properties